### PR TITLE
restructured project configs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,32 +1,33 @@
-{  "root": true
-,  "parser": "@typescript-eslint/parser"
-,  "plugins": ["@typescript-eslint"]
-,  "overrides": [{"files": "src/*.ts", "parserOptions": {"project": "tsconfig.json"}}]
-,  "rules":
-   {  "block-spacing": "error"
-   ,  "quote-props": ["error", "consistent-as-needed"]
-   ,  "@typescript-eslint/adjacent-overload-signatures": "warn"
-   ,  "@typescript-eslint/comma-dangle": ["error", "always-multiline"]
-   ,  "@typescript-eslint/comma-spacing": ["error", {"before": false, "after": true}]
-   ,  "@typescript-eslint/consistent-indexed-object-style": ["error", "index-signature"]
-   ,  "@typescript-eslint/consistent-type-assertions": ["error", {"assertionStyle": "as"}]
-   ,  "@typescript-eslint/explicit-function-return-type": "warn"
-   ,  "@typescript-eslint/keyword-spacing": "error"
-   ,  "@typescript-eslint/member-delimiter-style": "error"
-   ,  "@typescript-eslint/method-signature-style": ["error", "property"]
-   ,  "@typescript-eslint/no-confusing-void-expression": "error"
-   ,  "@typescript-eslint/no-duplicate-imports": "warn"
-   ,  "@typescript-eslint/no-extra-semi": "error"
-   ,  "@typescript-eslint/no-extra-non-null-assertion": "warn"
-   ,  "@typescript-eslint/no-loop-func": "warn"
-   ,  "@typescript-eslint/no-loss-of-precision": "error"
-   ,  "@typescript-eslint/no-require-imports": "error"
-   ,  "@typescript-eslint/object-curly-spacing": "error"
-   ,  "@typescript-eslint/quotes": ["error", "double", {"avoidEscape": true}]
-   ,  "@typescript-eslint/prefer-as-const": "warn"
-   ,  "@typescript-eslint/prefer-namespace-keyword": "error"
-   ,  "@typescript-eslint/space-before-blocks": "error"
-   ,  "@typescript-eslint/semi": ["error", "always", {"omitLastInOneLineBlock": true}]
-   ,  "@typescript-eslint/type-annotation-spacing": "warn"
+{
+   "root": true,
+   "parser": "@typescript-eslint/parser",
+   "plugins": ["@typescript-eslint"],
+   "parserOptions": {"project": "tsconfig.json"},
+   "rules": {
+      "block-spacing": "error",
+      "quote-props": ["error", "consistent-as-needed"],
+      "@typescript-eslint/adjacent-overload-signatures": "warn",
+      "@typescript-eslint/comma-dangle": ["error", "always-multiline"],
+      "@typescript-eslint/comma-spacing": ["error", {"before": false, "after": true}],
+      "@typescript-eslint/consistent-indexed-object-style": ["error", "index-signature"],
+      "@typescript-eslint/consistent-type-assertions": ["error", {"assertionStyle": "as"}],
+      "@typescript-eslint/explicit-function-return-type": "warn",
+      "@typescript-eslint/keyword-spacing": "error",
+      "@typescript-eslint/member-delimiter-style": "error",
+      "@typescript-eslint/method-signature-style": ["error", "property"],
+      "@typescript-eslint/no-confusing-void-expression": "error",
+      "@typescript-eslint/no-duplicate-imports": "warn",
+      "@typescript-eslint/no-extra-semi": "error",
+      "@typescript-eslint/no-extra-non-null-assertion": "warn",
+      "@typescript-eslint/no-loop-func": "warn",
+      "@typescript-eslint/no-loss-of-precision": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/object-curly-spacing": "error",
+      "@typescript-eslint/quotes": ["error", "double", {"avoidEscape": true}],
+      "@typescript-eslint/prefer-as-const": "warn",
+      "@typescript-eslint/prefer-namespace-keyword": "error",
+      "@typescript-eslint/space-before-blocks": "error",
+      "@typescript-eslint/semi": ["error", "always", {"omitLastInOneLineBlock": true}],
+      "@typescript-eslint/type-annotation-spacing": "warn"
    }
 }

--- a/Makefile
+++ b/Makefile
@@ -23,24 +23,18 @@ endif
 .PHONY: clean
 
 cjs:
-	tsc --module commonjs --outDir bin/cjs
-.PHONY: cjs
+	tsc -p tsconfig.cjs.json
 
-es6:
-	tsc --module es2020 --outDir bin/es6
-.PHONY: es6
+es6: $(src_files)
+	tsc -p tsconfig.esm.json
 
-dts:
-	tsc --module es2020 --emitDeclarationOnly --declaration --declarationDir bin/dts
+dts: es6
 	node add_command_comments
 .PHONY: dts
 
-zzz: cjs
-	node $@
-.PHONY: zzz
-
 test:
-	ava --verbose
+	tsc -p tsconfig.spec.json
+	ava bin/spec --verbose
 .PHONY: test
 
 publish: build

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,0 @@
-# foundatsion docs
-
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
    "name": "@axel-hq/foundatsion",
    "version": "0.6.2-alpha",
-   "description": "A library for runtime type-checking for TypeScript",
+   "description": "A library for runtime type-checking in TypeScript",
    "homepage": "https://github.com/axel-hq/foundatsion#readme",
    "repository": "git@github.com:axel-hq/foundatsion.git",
    "bugs": {
@@ -20,9 +20,7 @@
          "url": "https://github.com/rhiz0-eth"
       }
    ],
-   "files": [
-      "bin"
-   ],
+   "files": ["bin/cjs", "bin/es6", "bin/dts"],
    "exports": {
       "types": "./bin/dts/index.d.ts",
       "require": "./bin/cjs/index.js",
@@ -33,18 +31,9 @@
       "@typescript-eslint/parser": "^5.30.5",
       "ava": "^5.1.0",
       "eslint": "^8.22.0",
-      "ts-node": "^10.9.1",
       "typescript": "^4.9.4"
    },
    "engines": {
       "node": ">=16"
-   },
-   "ava": {
-      "extensions": [
-         "ts"
-      ],
-      "require": [
-         "ts-node/register"
-      ]
    }
 }

--- a/spec/all.spec.ts
+++ b/spec/all.spec.ts
@@ -1,0 +1,16 @@
+import {F} from ".";
+import test from "ava";
+
+const fields = [
+   "array", "any_fn", "assert", "assert_and_return", "auto", "bigint",
+   "boolean", "enum", "Error", "int", "inter", "never", "unwrap", "number",
+   "oo", "prim", "rtti", "string", "symbol", "text", "tuple", "__unreachable",
+   "ignore", "absurd", "id", "ct_true", "T", "tt", "ubigint", "uint", "union",
+   "unknown", "unsigned", "unsound", "ureal",
+];
+
+for (const field of fields) {
+   test(`F.${field} is truthy`, t => {
+      t.truthy((F as any)[field]);
+   });
+}

--- a/spec/any_fn.spec.ts
+++ b/spec/any_fn.spec.ts
@@ -2,11 +2,11 @@ import {F} from ".";
 import test from "ava";
 
 test("invariant: object", t => {
-   t.throws(() => F.any_fn.assert({}));
-})
+   t.throws(() => { F.any_fn.assert({}) });
+});
 
 test("invariant: number", t => {
-   t.throws(() => F.any_fn.assert(Math.random() * 3000));
+   t.throws(() => { F.any_fn.assert(Math.random() * 3000) });
 });
 
 test("imbue makes new function", t => {

--- a/spec/real.spec.ts
+++ b/spec/real.spec.ts
@@ -24,7 +24,7 @@ two_or_three satisfies 2 | 3;
 
 test("invariant: NaN", t => {
    const v = NaN;
-   t.false(F.real.is(v))
+   t.false(F.real.is(v));
    t.throws(() => {
       F.real.assert(v);
    });
@@ -32,7 +32,7 @@ test("invariant: NaN", t => {
 
 test("invariant: Infinity", t => {
    const v = Infinity;
-   t.false(F.real.is(v))
+   t.false(F.real.is(v));
    t.throws(() => {
       F.real.assert(v);
    });
@@ -40,7 +40,7 @@ test("invariant: Infinity", t => {
 
 test("invariant: -Infinity", t => {
    const v = -Infinity;
-   t.false(F.real.is(v))
+   t.false(F.real.is(v));
    t.throws(() => {
       F.real.assert(v);
    });

--- a/src/oo.ts
+++ b/src/oo.ts
@@ -47,8 +47,6 @@ export namespace oo {
       } catch (e) {
          if (e instanceof Error) {
             throw new FoundatsionError(
-               // JSON.stringify(k) is used to escape quotes and other weird
-               // characters within k.
                `While asserting for {[${text.show(k)}]: ${t.name}}`,
                "an error was thrown:",
                e,
@@ -66,5 +64,3 @@ export namespace oo {
       return unsound.shut_up(Object.keys(o));
    }
 }
-
-type z = keyof ({a: 1} | {b: 2});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+   "compilerOptions": {
+      "exactOptionalPropertyTypes": true,
+      "noImplicitAny": true,
+      "noImplicitReturns": true,
+      "noImplicitThis": true,
+      "noUncheckedIndexedAccess": true,
+      "strict": true,
+      "useUnknownInCatchVariables": true,
+      "moduleResolution": "node16",
+      "newLine": "lf",
+      "noEmitOnError": true,
+      "sourceMap": true,
+      "removeComments": false,
+      "esModuleInterop": true,
+      "forceConsistentCasingInFileNames": true,
+      "lib": ["es2020", "dom"],
+      "target": "es2020",
+   },
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+   "extends": "./tsconfig.base.json",
+   "include": ["src/*.ts"],
+   "compilerOptions": {
+      "module": "commonjs",
+      "outDir": "bin/cjs",
+   },
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+   "extends": "./tsconfig.base.json",
+   "include": ["src/*.ts"],
+   "compilerOptions": {
+      "module": "es2020",
+      "outDir": "bin/esm",
+      "declaration": true,
+      "declarationDir": "bin/dts",
+   },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,4 @@
-{  "compilerOptions":
-   // type checking
-   {  "exactOptionalPropertyTypes": true
-   ,  "noImplicitAny": true
-   ,  "noImplicitReturns": true
-   ,  "noImplicitThis": true
-   ,  "noUncheckedIndexedAccess": true
-   ,  "strict": true
-   ,  "useUnknownInCatchVariables": true
-   // modules
-   ,  "moduleResolution": "node16"
-   // emit
-   ,  "newLine": "lf"
-   ,  "noEmitOnError": true
-   ,  "sourceMap": true
-   ,  "removeComments": false
-   // interop constraints
-   ,  "esModuleInterop": true
-   ,  "forceConsistentCasingInFileNames": true
-   // Language and Environment
-   ,  "lib": ["es2020", "dom"]
-   ,  "target": "es2020"
-   }
-,  "include": ["src/*.ts"]
+{
+   "extends": "./tsconfig.base.json",
+   "include": ["src/*.ts", "spec/*.spec.ts"],
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+   "extends": "./tsconfig.base.json",
+   "include": ["spec/*.spec.ts"],
+   "compilerOptions": {
+      "module": "commonjs",
+      "outDir": "bin/spec",
+   },
+}


### PR DESCRIPTION
also removed the dependency on ts-node!
this means that tests that do not compile won't just hang.